### PR TITLE
add CA Certificate options to configuration file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.9.1
+    sha: v0.9.5
     hooks:
     -   id: trailing-whitespace
     -   id: flake8

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ Upload URL (https://ingest.example.com/upload):
 Status URL (https://ingest.example.com/get_state):
 Policy URL (https://policy.example.com/uploader):
 
+CA certificate bundle is the path to your certificate authority bundle.
+
+Use this if you have a custom site SSL Certificate for your Site.
+
+Valid values:
+- True: verify the SSL server certificiate using system bundle
+- False: do not verify the SSL server certificate (not recommended)
+- a/path/to/a/cacert/bundle: custom path to the server certificate
+
+CA Certificate Bundle (True):
+
 There are three kinds of authentication types supported.
 
 - clientssl - This is where you have an SSL client key and cert

--- a/tests/methods_test.py
+++ b/tests/methods_test.py
@@ -15,6 +15,8 @@ class config_client(object):
     def __enter__(self):
         """Create a config parser object with appropriate values."""
         config = ConfigParser()
+        config.add_section('endpoints')
+        config.set('endpoints', 'ca_bundle', 'True')
         config.add_section('authentication')
         config.set('authentication', 'type', self.auth_type)
         config.set('authentication', 'username', 'username')

--- a/tests/methods_test.py
+++ b/tests/methods_test.py
@@ -40,6 +40,7 @@ class TestMethods(TestCase):
             self.assertTrue('cert' in generate_requests_auth(conf))
             self.assertEqual(generate_requests_auth(conf)['cert'][0], 'cert')
             self.assertTrue(generate_requests_auth(conf)['cert'][1], 'key')
+            self.assertTrue(generate_requests_auth(conf)['verify'], 'True')
         with config_client('basic') as conf:
             self.assertTrue('auth' in generate_requests_auth(conf))
             self.assertTrue(generate_requests_auth(conf)['auth'][0], 'username')

--- a/tests/methods_test.py
+++ b/tests/methods_test.py
@@ -2,7 +2,7 @@
 """Test the methods module for things we need to test."""
 from unittest import TestCase
 from ConfigParser import ConfigParser
-from uploader_cli.methods import generate_requests_auth
+from uploader_cli.methods import generate_requests_auth, verify_type
 
 
 class config_client(object):
@@ -45,3 +45,15 @@ class TestMethods(TestCase):
             self.assertTrue('auth' in generate_requests_auth(conf))
             self.assertTrue(generate_requests_auth(conf)['auth'][0], 'username')
             self.assertTrue(generate_requests_auth(conf)['auth'], 'password')
+
+    def test_verify_type(self):
+        """Test the verify_type method to cover everything."""
+        self.assertEqual(verify_type('True'), True)
+        self.assertEqual(verify_type('False'), False)
+        self.assertEqual(verify_type('/etc/hosts'), '/etc/hosts')
+        hit_exception = False
+        try:
+            verify_type('blarg')
+        except ValueError:
+            hit_exception = True
+        self.assertTrue(hit_exception)

--- a/travis/before-install.sh
+++ b/travis/before-install.sh
@@ -10,7 +10,9 @@ if [ -z "$RUN_LINTS" ]; then
   export MYSQL_ENV_MYSQL_PASSWORD=
   archiveinterfaceserver.py --config travis/config.cfg &
   echo $! > archiveinterface.pid
+  pushd travis/uniqueid
   UniqueIDServer.py &
+  popd
   pushd travis/metadata
   MetadataServer.py &
   popd

--- a/travis/uniqueid/server.conf
+++ b/travis/uniqueid/server.conf
@@ -1,0 +1,11 @@
+[global]
+log.screen: True
+log.access_file: 'access.log'
+log.error_file: 'error.log'
+server.socket_host: '0.0.0.0'
+server.socket_port: 8051
+
+[/]
+request.dispatch: cherrypy.dispatch.MethodDispatcher()
+tools.response_headers.on: True
+tools.response_headers.headers: [('Content-Type', 'application/json')]

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -25,7 +25,7 @@ coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py configu
 ############################
 # Build testing config
 ############################
-printf 'http://localhost:8066/upload\nhttp://localhost:8066/get_state\nhttp://localhost:8181/uploader\nNone\n' |
+printf 'http://localhost:8066/upload\nhttp://localhost:8066/get_state\nhttp://localhost:8181/uploader\nTrue\nNone\n' |
 python CLIUploader.py configure
 
 ############################

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -17,9 +17,9 @@ coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py configu
 # Configure commands
 ############################
 yes | coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py configure
-printf '\n\n\nclientssl\n~/.pacifica-cli/my.key\n~/.pacifica-cli/my.cert\n' |
+printf '\n\n\nTrue\nclientssl\n~/.pacifica-cli/my.key\n~/.pacifica-cli/my.cert\n' |
 coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py configure
-printf '\n\n\nbasic\nusername\npassword\n' |
+printf '\n\n\nFalse\nbasic\nusername\npassword\n' |
 coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py configure
 
 ############################
@@ -33,10 +33,10 @@ python CLIUploader.py configure
 ############################
 coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py upload --dry-run --instrument 54 --logon dmlb2001
 export PAGER=""
-printf '\n\n\n' | coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py upload --dry-run --interactive --logon dmlb2001
+printf '\n\n\n\n' | coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py upload --dry-run --interactive --logon dmlb2001
 export PAGER=cat
-printf '\n\n\n' | coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py upload --dry-run --interactive --logon dmlb2001
-printf '8192\n\n\n\n' | coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py upload --dry-run --interactive --logon dmlb2001
+printf '\n\n\n\n' | coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py upload --dry-run --interactive --logon dmlb2001
+printf '8192\n\n\n\n\n' | coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py upload --dry-run --interactive --logon dmlb2001
 curl -X POST -H 'content-type: application/json' 'localhost:8121/users?_id=11' -d'{ "network_id": "'`whoami`'"}'
 # this will fail...
 coverage run --include='uploader_cli/*,CLIUploader.py' -a CLIUploader.py --verbose debug upload --dry-run --instrument 54 || true

--- a/uploader_cli/configure.py
+++ b/uploader_cli/configure.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 from sys import stdin, stdout
 
-__all__ = ['configure_url_endpoints', 'configure_auth']
+__all__ = ['configure_url_endpoints', 'configure_ca_bundle', 'configure_auth']
 
 
 def configure_url_endpoints(global_ini):
@@ -20,6 +20,25 @@ What are the endpoint URLs for the following...
         strip_input = stdin.readline().strip()
         if strip_input:
             global_ini.set('endpoints', '{}_url'.format(endpnt), strip_input)
+
+
+def configure_ca_bundle(global_ini):
+    """Query for the ca bundle when using https."""
+    default_verify = global_ini.get('endpoints', 'ca_bundle')
+    print("""
+CA certificate bundle is the path to your certificate authority bundle.
+
+Use this if you have a custom site SSL Certificate for your Site.
+
+Valid values:
+ - True: verify the SSL server certificiate using system bundle
+ - False: do not verify the SSL server certificate (not recommended)
+ - a/path/to/a/cacert/bundle: custom path to the server certificate
+""")
+    stdout.write('CA Certificate Bundle ({}): '.format(default_verify))
+    strip_input = stdin.readline().strip()
+    if strip_input:
+        global_ini.set('endpoints', 'ca_bundle', strip_input)
 
 
 def configure_client_ssl(global_ini):

--- a/uploader_cli/configure.py
+++ b/uploader_cli/configure.py
@@ -3,7 +3,11 @@
 from __future__ import print_function
 from sys import stdin, stdout
 
-__all__ = ['configure_url_endpoints', 'configure_ca_bundle', 'configure_auth']
+__all__ = [
+    'configure_url_endpoints',
+    'configure_ca_bundle',
+    'configure_auth'
+]
 
 
 def configure_url_endpoints(global_ini):

--- a/uploader_cli/configure.py
+++ b/uploader_cli/configure.py
@@ -35,9 +35,9 @@ CA certificate bundle is the path to your certificate authority bundle.
 Use this if you have a custom site SSL Certificate for your Site.
 
 Valid values:
- - True: verify the SSL server certificiate using system bundle
- - False: do not verify the SSL server certificate (not recommended)
- - a/path/to/a/cacert/bundle: custom path to the server certificate
+- True: verify the SSL server certificiate using system bundle
+- False: do not verify the SSL server certificate (not recommended)
+- a/path/to/a/cacert/bundle: custom path to the server certificate
 """)
     stdout.write('CA Certificate Bundle ({}): '.format(default_verify))
     strip_input = stdin.readline().strip()


### PR DESCRIPTION
### Description

This adds the options to allow the client to load a custom CA Cert bundle for site specific SSL Certificates.
### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
